### PR TITLE
Bump up version of PMS, change vhost redirections

### DIFF
--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+  - name: restart nginx
+    service: name=nginx state=restarted

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -11,15 +11,23 @@
 - name: Configure nginx.conf
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
             owner=root group=root mode=0644
+  notify:
+    - restart nginx
 - name: Configure nginx services.conf
   template: src=services.conf.j2 dest=/etc/nginx/services.conf
             owner=root group=root mode=0644
+  notify:
+    - restart nginx
 - name: Configure nginx proxy-control.conf
   template: src=proxy-control.conf.j2 dest=/etc/nginx/proxy-control.conf
             owner=root group=root mode=0644
+  notify:
+    - restart nginx
 - name: Configure nginx auth-basic.conf
   template: src=auth-basic.conf.j2 dest=/etc/nginx/auth-basic.conf
             owner=root group=root mode=0644
+  notify:
+    - restart nginx
 - name: Configure nginx .htpasswd users file
   htpasswd: path=/etc/nginx/.htpasswd name={{ htpasswd_name }}
             password={{ htpasswd_password }}

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -19,7 +19,7 @@ http {
 
     server {
         listen 80;
-        server_name {{ server_name }};
+        server_name _;
 
         # Redirect to SSL
         rewrite ^ https://$host$request_uri? permanent;
@@ -27,7 +27,7 @@ http {
 
     server {
         listen 443;
-        server_name {{ server_name }};
+        server_name _;
 
         ssl on;
         ssl_certificate {{ nginx_ssl_cert }};

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -22,7 +22,7 @@ http {
         server_name {{ server_name }};
 
         # Redirect to SSL
-        rewrite ^ https://$server_name$request_uri? permanent;
+        rewrite ^ https://$host$request_uri? permanent;
     }
 
     server {

--- a/roles/nginx/templates/proxy-control.conf.j2
+++ b/roles/nginx/templates/proxy-control.conf.j2
@@ -18,24 +18,11 @@ proxy_set_header        X-Real-IP               $remote_addr;
 proxy_set_header        X-Forwarded-Host        $host;
 proxy_set_header        X-Forwarded-Server      $host;
 proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
-#proxy_set_header       X-Forwarded-For         $remote_addr;
 
 proxy_set_header        X-Forwarded-Port        '443';
 proxy_set_header        X-Forwarded-Ssl         on;
 proxy_set_header        X-Forwarded-Proto       https;
 proxy_set_header        Authorization           '';
 
-#proxy_buffering        off;
-
-#proxy_redirect        off;
-#proxy_redirect        default;
 proxy_redirect         http://{{ server_name }}/ /;
 proxy_redirect         https://{{ server_name }}/ /;
-#proxy_redirect        http://$host/ /;
-#proxy_redirect        http:// https://;
-
-#more_clear_headers    'referer';
-#RequestHeader unset   referer
-#proxy_hide_header     referer;
-#proxy_ignore_headers  referer;
-

--- a/roles/nginx/templates/services.conf.j2
+++ b/roles/nginx/templates/services.conf.j2
@@ -2,6 +2,7 @@
 # Sickbeard
 location {{ sickbeard_webroot }} {
         proxy_pass        http://localhost:{{ sickbeard_port }}{{ sickbeard_webroot }}/;
+        proxy_redirect    http://localhost:{{ sickbeard_port }}{{ sickbeard_webroot }}/ https://$host{{ sickbeard_webroot }};
         include           proxy-control.conf;
 }
 {% endif %}
@@ -10,6 +11,7 @@ location {{ sickbeard_webroot }} {
 # Sabnzbd
 location {{ sabnzbd_webroot }} {
         proxy_pass        http://localhost:{{ sabnzbd_port }}/sabnzbd;
+        proxy_redirect    http://localhost:{{ sabnzbd_port }}/sabnzbd https://$host{{ sabnzbd_webroot }};
         include           proxy-control.conf;
 }
 {% endif %}
@@ -17,15 +19,17 @@ location {{ sabnzbd_webroot }} {
 {% if include_nzbdrone %}
 # NZBDrone
 location {{ nzbdrone_webroot }} {
-        proxy_pass        http://localhost:{{ nzbdrone_port }}{{ nzbdrone_webroot }};
+        proxy_pass        http://localhost:{{ nzbdrone_port }};
+        proxy_redirect    http://localhost:{{ nzbdrone_port }}{{ nzbdrone_webroot }} https://$host{{ nzbdrone_webroot }};
         include proxy-control.conf;
 }
 {% endif %}
 
 {% if include_couchpotato %}
 # Couchpotato
-location /{{ couchpotato_webroot }} {
-        proxy_pass        http://localhost:{{ couchpotato_port }}/{{ couchpotato_webroot }};
+location {{ couchpotato_webroot }} {
+        proxy_pass        http://localhost:{{ couchpotato_port }};
+        proxy_redirect    http://localhost:{{ couchpotato_port }} https://$host{{ couchpotato_webroot }};
         include           proxy-control.conf;
         proxy_redirect    off;
 }
@@ -35,6 +39,7 @@ location /{{ couchpotato_webroot }} {
 # Transmission
 location {{ transmission_webroot }} {
     proxy_pass http://localhost:{{ transmission_port }};
+    proxy_redirect http://localhost:{{ transmission_port }} https://$host{{ transmission_webroot }};
     proxy_pass_header X-Transmission-Session-Id;
     include proxy-control.conf;
 }

--- a/roles/nzbdrone/tasks/main.yml
+++ b/roles/nzbdrone/tasks/main.yml
@@ -29,16 +29,5 @@
   template: src=config.xml.j2 dest="{{ nzbdrone_home }}/.config/NzbDrone/config.xml"
 - name: Install NZBDrone upstart script (ubuntu 14.04 or earlier)
   template: src=nzbdrone.conf.j2 dest=/etc/init/nzbdrone.conf
-- name: Block connections to NZBDrone from world
-  #ufw: rule=deny port={{ nzbdrone_port }}
-  command: "ufw deny 8011"
-- name: Allow connections to NZBDrone from localhost
-  #ufw: rule=allow port={{ nzbdrone_port }} src=127.0.0.1
-  command: "ufw allow from 127.0.0.1 to any port 8011"
-- name: Default ufw to allow connections.
-  command: "ufw default allow"
-- name: Ensure ufw is running.
-  #ufw: state=enabled
-  command: "ufw enable"
 - name: Ensure NZBDrone is running
   service: name=nzbdrone state=started

--- a/roles/nzbdrone/tasks/main.yml
+++ b/roles/nzbdrone/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Block connections to NZBDrone from world
   #ufw: rule=deny port={{ nzbdrone_port }}
   command: "ufw deny 8011"
-- name: Allow conncetions to NZBDrone from localhost
+- name: Allow connections to NZBDrone from localhost
   #ufw: rule=allow port={{ nzbdrone_port }} src=127.0.0.1
   command: "ufw allow from 127.0.0.1 to any port 8011"
 - name: Default ufw to allow connections.

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -29,9 +29,6 @@
 - name: Installing plex
   command: "dpkg -i {{ plex_deb_path }}"
   when: result|failed
-#- name: Ensure the Unofficial Plex App Store is installed
-#  command: git clone {{ app_store_repo }} "{{ plex_application_support_dir }}/Plug-ins/AppStore.bundle"
-#           creates="{{ plex_application_support_dir }}/Plug-ins/AppStore.bundle"
 
 # Start it
 - name: Ensure plex is running

--- a/roles/plex/vars/main.yml
+++ b/roles/plex/vars/main.yml
@@ -1,4 +1,3 @@
 plex_download: https://downloads.plex.tv/plex-media-server/0.9.12.11.1406-8403350/plexmediaserver_0.9.12.11.1406-8403350_amd64.deb
-plex_deb_path: /tmp/plex.deb
+plex_deb_path: /tmp/plexmediaserver_0.9.12.11.1406-8403350_amd64.deb
 plex_application_support_dir: "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server"
-app_store_repo: "git://github.com/mikedm139/UnSupportedAppstore.bundle.git"

--- a/roles/plex/vars/main.yml
+++ b/roles/plex/vars/main.yml
@@ -1,4 +1,4 @@
-plex_download: https://downloads.plex.tv/plex-media-server/0.9.12.4.1192-9a47d21/plexmediaserver_0.9.12.4.1192-9a47d21_amd64.deb
+plex_download: https://downloads.plex.tv/plex-media-server/0.9.12.11.1406-8403350/plexmediaserver_0.9.12.11.1406-8403350_amd64.deb
 plex_deb_path: /tmp/plex.deb
 plex_application_support_dir: "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server"
 app_store_repo: "git://github.com/mikedm139/UnSupportedAppstore.bundle.git"

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -11,6 +11,6 @@
   when: installed|changed
 - name: Ensure download dir exists
   file: path={{ transmission_download_dir }}
-        owner={{ user }} group={{ user_group }} state=directory mode=0775
+        owner={{ user }} group={{ user_group }} state=directory mode=0777
 - name: Ensure transmission is running
   service: name=transmission-daemon state=started enabled=yes

--- a/roles/transmission/tasks/main.yml
+++ b/roles/transmission/tasks/main.yml
@@ -11,6 +11,6 @@
   when: installed|changed
 - name: Ensure download dir exists
   file: path={{ transmission_download_dir }}
-        owner={{ user }} group={{ user_group }} state=directory mode=0777
+        owner={{ user }} group={{ user_group }} state=directory mode=0775
 - name: Ensure transmission is running
   service: name=transmission-daemon state=started enabled=yes

--- a/roles/transmission/templates/config.json.j2
+++ b/roles/transmission/templates/config.json.j2
@@ -63,7 +63,7 @@
     "speed-limit-up-enabled": false,
     "start-added-torrents": true,
     "trash-original-torrent-files": false,
-    "umask": 18,
+    "umask": 2,
     "upload-limit": 100,
     "upload-limit-enabled": 0,
     "upload-slots-per-torrent": 14,


### PR DESCRIPTION
I recently got a chance to use this playbook for setting up a new server, and found a few things not quite right. I made a few changes, in case anyone else runs into the same problems:

- [x] updated the version of Plex Media Server
- [x] updated vhost to listen on wildcard address (`_`)
- [x] removed broken ufw rules for nzbdrone (didn't work for me; kept hanging and timing out)
- [x] added handler to restart nginx when vhost changes are made
- [x] updated Transmission settings to have less restrictive permissions on downloaded files
- [x] removed unnecessary comments 
- [x] removed references to Plex app store